### PR TITLE
Exclude non-public methods from controller verification

### DIFF
--- a/Rule/Symfony2/ControllerMethodName.php
+++ b/Rule/Symfony2/ControllerMethodName.php
@@ -29,6 +29,10 @@ class ControllerMethodName extends AbstractRule implements ClassAware
 
         /** @var MethodNode $method */
         foreach ($node->getMethods() as $method) {
+            if (false === $method->isPublic()) {
+                continue;
+            }
+            
             if ('Action' !== substr($method->getImage(), -6, 6)) {
                 $this->addViolation($method);
             }

--- a/Tests/Unit/Symfony2/ControllerMethodNameTest.php
+++ b/Tests/Unit/Symfony2/ControllerMethodNameTest.php
@@ -41,23 +41,32 @@ class ControllerMethodNameTest extends AbstractApplyTest
     public function testApplyWithDirtyController()
     {
         $className = 'TestController';
-        $validMethodName = 'testAction';
-        $notValidMethodName = 'doSomething';
+        $validPublicMethodName = 'testAction';
+        $notValidPublicMethodName = 'doSomething';
+        $validPrivateMethodName = 'createMyAwesomeForm';
 
-        $validMethodNode = \Mockery::mock('PHPMD\Node\MethodNode');
-        $validMethodNode->shouldReceive('getImage')->andReturn($validMethodName);
-        $validMethodNode->shouldReceive('getParentName')->andReturn($className);
-        $validMethodNode->shouldReceive('getName')->andReturn($validMethodName);
+        $validPublicMethodNode = \Mockery::mock('PHPMD\Node\MethodNode');
+        $validPublicMethodNode->shouldReceive('getImage')->andReturn($validPublicMethodName);
+        $validPublicMethodNode->shouldReceive('getParentName')->andReturn($className);
+        $validPublicMethodNode->shouldReceive('getName')->andReturn($validPublicMethodName);
+        $validPublicMethodNode->shouldReceive('isPublic')->andReturn(true);
 
-        $notValidMethodNode = \Mockery::mock('PHPMD\Node\MethodNode');
-        $notValidMethodNode->shouldReceive('getImage')->andReturn($notValidMethodName);
-        $notValidMethodNode->shouldReceive('getParentName')->andReturn($className);
-        $notValidMethodNode->shouldReceive('getName')->andReturn($notValidMethodName);
+        $notValidPublicMethodNode = \Mockery::mock('PHPMD\Node\MethodNode');
+        $notValidPublicMethodNode->shouldReceive('getImage')->andReturn($notValidPublicMethodName);
+        $notValidPublicMethodNode->shouldReceive('getParentName')->andReturn($className);
+        $notValidPublicMethodNode->shouldReceive('getName')->andReturn($notValidPublicMethodName);
+        $notValidPublicMethodNode->shouldReceive('isPublic')->andReturn(true);
+
+        $validPrivateMethodNode = \Mockery::mock('PHPMD\Node\MethodNode');
+        $validPrivateMethodNode->shouldReceive('getImage')->andReturn($validPrivateMethodName);
+        $validPrivateMethodNode->shouldReceive('getParentName')->andReturn($className);
+        $validPrivateMethodNode->shouldReceive('getName')->andReturn($validPrivateMethodName);
+        $validPrivateMethodNode->shouldReceive('isPublic')->andReturn(false);
 
         $classNode = \Mockery::mock('PHPMD\Node\ClassNode');
         $classNode->shouldReceive('isAbstract')->andReturn(false);
         $classNode->shouldReceive('getImage')->andReturn($className);
-        $classNode->shouldReceive('getMethods')->andReturn([$validMethodNode, $notValidMethodNode]);
+        $classNode->shouldReceive('getMethods')->andReturn([$validPublicMethodNode, $notValidPublicMethodNode, $validPrivateMethodNode]);
 
         $this->assertRule($classNode, 1);
     }


### PR DESCRIPTION
Controller methods should be postfixed with `Action` only if they are callable. If the method is private/protected, it can't be callable since it can't be mapped to any route. Then verification of non-public methods doesn't make any sense.
