### PR TITLE
Allow configuration of allowed method names in ControllerMethodName rule

### DIFF
--- a/Rule/Symfony2/ControllerMethodName.php
+++ b/Rule/Symfony2/ControllerMethodName.php
@@ -27,8 +27,15 @@ class ControllerMethodName extends AbstractRule implements ClassAware
             return;
         }
 
+        $allowedMethodNames = explode($this->getStringProperty('delimiter'), $this->getStringProperty('allowedMethodNames'));
+
         /** @var MethodNode $method */
         foreach ($node->getMethods() as $method) {
+            // Check if method is whitelisted
+            if (true === in_array($method->getImage(), $allowedMethodNames)) {
+              continue;
+            }
+
             if ('Action' !== substr($method->getImage(), -6, 6)) {
                 $this->addViolation($method);
             }

--- a/Rulesets/symfony2.xml
+++ b/Rulesets/symfony2.xml
@@ -17,6 +17,10 @@ So you have to outsource your business logic to services or event listeners.
             ]]>
         </description>
         <priority>3</priority>
+        <properties>
+            <property name="delimiter" value="," description="delimiter for explode" />
+            <property name="allowedMethodNames" value="__construct" description="whitelist for method names. These are allowed reside in the controller though they are no actions." />
+        </properties>
         <example>
             <![CDATA[
 class FooController

--- a/Tests/Fixtures/AppBundle/Controller/FooController.php
+++ b/Tests/Fixtures/AppBundle/Controller/FooController.php
@@ -8,6 +8,18 @@ namespace AppBundle\Controller;
 class FooController extends AbstractFooController
 {
     /**
+    * @var string
+    */
+    protected $foo;
+
+    /**
+    * @param string $bar
+    */
+    public function __construct($bar = 'just an example') {
+        $this->foo = $bar;
+    }
+
+    /**
      * good
      */
     public function barAction()

--- a/Tests/Functional/Symfony2/ControllerMethodNameTest.php
+++ b/Tests/Functional/Symfony2/ControllerMethodNameTest.php
@@ -20,7 +20,8 @@ class ControllerMethodNameTest extends AbstractProcessTest
             ->runPhpmd('Controller/FooController.php', 'symfony2.xml')
             ->getOutput();
 
-        $this->assertContains('Controller/FooController.php:21	The method name should end with Action in this controller.', $output);
+        $this->assertNotContains('Controller/FooController.php:18	The method name should end with Action in this controller.', $output);
+        $this->assertContains('Controller/FooController.php:33	The method name should end with Action in this controller.', $output);
     }
 
     /**

--- a/Tests/Unit/Symfony2/ControllerMethodNameTest.php
+++ b/Tests/Unit/Symfony2/ControllerMethodNameTest.php
@@ -67,6 +67,10 @@ class ControllerMethodNameTest extends AbstractApplyTest
      */
     protected function getRule()
     {
-        return new ControllerMethodName();
+        $rule = new ControllerMethodName();
+        $rule->addProperty('delimiter', ',');
+        $rule->addProperty('allowedMethodNames', '__construct');
+
+        return $rule;
     }
 }


### PR DESCRIPTION
The rule breaks when using any type of inversion of control that doesn't use the container directly.

The patchset enhances the ruleset to be able to configure the allowed method names with a sensible default containing only `__construct` so constructor injection is not a smell anymore.
